### PR TITLE
fix(ios): Fixing wrong Firebase dependency

### DIFF
--- a/CapacitorFcm.podspec
+++ b/CapacitorFcm.podspec
@@ -10,7 +10,6 @@
     s.source_files = 'ios/Plugin/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
     s.ios.deployment_target  = '11.0'
     s.dependency 'Capacitor'
-    s.dependency 'Firebase'
     s.dependency 'FirebaseCore'
     s.dependency 'FirebaseMessaging'
     s.static_framework = true


### PR DESCRIPTION
While updating my project to Capacitor 2 I have encountered the following problem:

<img width="518" alt="Captura de pantalla 2020-05-02 a las 13 16 06" src="https://user-images.githubusercontent.com/2467193/80862822-3b797080-8c78-11ea-9849-3ce777cebdab.png">

The problem is causing due to `capacitor-fcm`. Two different `Firebase` versions are being attempted to install:

<img width="736" alt="Captura de pantalla 2020-05-02 a las 11 45 28" src="https://user-images.githubusercontent.com/2467193/80862829-4af8b980-8c78-11ea-9801-4911b850f05b.png">

This minor change solves the problem. Tested in the following environment:

```
💊   Capacitor Doctor  💊 

Latest Dependencies:

  @capacitor/cli: 2.0.2

  @capacitor/core: 2.0.2

  @capacitor/android: 2.0.2

  @capacitor/electron: 2.0.2

  @capacitor/ios: 2.0.2

Installed Dependencies:

  @capacitor/electron not installed


  @capacitor/cli 2.0.2

  @capacitor/ios 2.0.2

  @capacitor/android 2.0.2

  @capacitor/core 2.0.2

[success] Android looking great! 👌
  Found 11 Capacitor plugins for ios:
    @jonoj/capacitor-fused-location (1.2.1)
    capacitor-fcm (2.0.0)
    cordova-plugin-badge (0.8.8)
    cordova-plugin-facebook4 (6.4.0)
    cordova-plugin-file (6.0.2)
    cordova-plugin-file-opener2 (3.0.0)
    cordova-plugin-file-transfer (1.7.1)
    cordova-plugin-googleplus (8.4.0)
    cordova-plugin-ionic (5.4.7)
    cordova-plugin-whitelist (1.3.4)
    cordova-sqlite-storage (5.0.0)
[success] iOS looking great! 👌

```


