### PR TITLE
use 2.0.0 instead of latest in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Stewan Silva",
   "license": "MIT",
   "dependencies": {
-    "@capacitor/core": "latest"
+    "@capacitor/core": "^2.0.0"
   },
   "devDependencies": {
     "all-contributors-cli": "^6.16.0",


### PR DESCRIPTION
See mike's comment here:

https://github.com/ionic-team/capacitor/issues/3200