### PR TITLE
fix(ios): get token using instanceID

### DIFF
--- a/ios/Plugin/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin/Plugin.swift
@@ -60,10 +60,15 @@ public class FCM: CAPPlugin, MessagingDelegate {
     }
     
     @objc func getToken(_ call: CAPPluginCall) {
-        let token = Messaging.messaging().fcmToken ?? ""
-            call.success([
-            "token": token
-        ])
+        InstanceID.instanceID().instanceID { (result, error) in
+            if let error = error {
+                call.error("Failed to get instance FirebaseID", error)
+            } else {
+                call.success([
+                    "token": result?.token
+                ]);
+            }
+        }
     }
     
     @objc func deleteInstance(_ call: CAPPluginCall) {


### PR DESCRIPTION
getToken returns an empty string right after deleteInstance. This fix updates the getToken method to match the android version, where it will wait for a valid instance & token before returning.