### PR TITLE
Add setAutoInitEnabled and isAutoInitEnabled methods to control the auto initialization of the library

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ fcm
   .then(() => alert(`Auto init enabled`))
 
 //
-// Checkthe auto initialization status
+// Check the auto initialization status
 fcm
   .isAutoInitEnabled()
   .then((r) => {

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ npx cap sync
 | `unsubscribeFrom`    | unsubscribe from fcm topic                    | ios/android |
 | `getToken`           | get fcm token to eventually use from a server | ios/android |
 | `deleteInstance`     | remove local fcm instance completely          | ios/android |
-| `setAutoInitEnabled` | enable the auto initialization of the library | ios/android |
+| `setAutoInit`        | enable the auto initialization of the library | ios/android |
 | `isAutoInitEnabled`  | check whether auto initialization is enabled  | ios/android |
 
 ## Usage
@@ -117,7 +117,7 @@ fcm
 //
 // Enable the auto initialization of the library
 fcm
-  .setAutoInitEnabled({ enabled: true })
+  .setAutoInit({ enabled: true })
   .then(() => alert(`Auto init enabled`))
 
 //

--- a/README.md
+++ b/README.md
@@ -54,12 +54,14 @@ npx cap sync
 
 ## API
 
-| method            | info                                          | platform    |
-| ----------------- | --------------------------------------------- | ----------- |
-| `subscribeTo`     | subscribe to fcm topic                        | ios/android |
-| `unsubscribeFrom` | unsubscribe from fcm topic                    | ios/android |
-| `getToken`        | get fcm token to eventually use from a server | ios/android |
-| `deleteInstance`  | remove local fcm instance completely          | ios/android |
+| method               | info                                          | platform    |
+| -------------------- | --------------------------------------------- | ----------- |
+| `subscribeTo`        | subscribe to fcm topic                        | ios/android |
+| `unsubscribeFrom`    | unsubscribe from fcm topic                    | ios/android |
+| `getToken`           | get fcm token to eventually use from a server | ios/android |
+| `deleteInstance`     | remove local fcm instance completely          | ios/android |
+| `setAutoInitEnabled` | enable the auto initialization of the library | ios/android |
+| `isAutoInitEnabled`  | check whether auto initialization is enabled  | ios/android |
 
 ## Usage
 
@@ -111,6 +113,20 @@ fcm
   .deleteInstance()
   .then(() => alert(`Token deleted`))
   .catch((err) => console.log(err));
+
+//
+// Enable the auto initialization of the library
+fcm
+  .setAutoInitEnabled({ enabled: true })
+  .then(() => alert(`Auto init enabled`))
+
+//
+// Checkthe auto initialization status
+fcm
+  .isAutoInitEnabled()
+  .then((r) => {
+    console.log('Auto init is ' + (r.enabled ? 'enabled' : 'disabled'))
+  })
 ```
 
 ## Add Google config files
@@ -160,6 +176,10 @@ Download the `google-services.json` file and copy it to `android/app/` directory
 
 > Tip: every time you change a native code you may need to clean up the cache (Product > Clean build folder) and then run the app again.
 
+### Prevent auto initialization
+
+If you need to implement opt-in behavior, you can disable the auto initialization of the library by following the [Firebase docs](https://firebase.google.com/docs/cloud-messaging/ios/client#prevent_auto_initialization).
+
 ## Android setup
 
 - `ionic start my-cap-app --capacitor`
@@ -177,6 +197,10 @@ Download the `google-services.json` file and copy it to `android/app/` directory
 Now you should be set to go. Try to run your client using `ionic cap run android --livereload`.
 
 > Tip: every time you change a native code you may need to clean up the cache (Build > Clean Project | Build > Rebuild Project) and then run the app again.
+
+### Prevent auto initialization
+
+If you need to implement opt-in behavior, you can disable the auto initialization of the library by following the [Firebase docs](https://firebase.google.com/docs/cloud-messaging/android/client#prevent-auto-init).
 
 ## Example
 

--- a/android/src/main/java/com/getcapacitor/community/fcm/FCMPlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/fcm/FCMPlugin.java
@@ -77,4 +77,19 @@ public class FCMPlugin extends Plugin {
         });
         FirebaseInstanceId.getInstance().getInstanceId().addOnFailureListener(e -> call.error("Failed to get instance FirebaseID", e));
     }
+
+    @PluginMethod()
+    public void setAutoInitEnabled(final PluginCall call) {
+        final boolean enabled = call.getBoolean("enabled", false);
+        FirebaseMessaging.getInstance().setAutoInitEnabled(enabled);
+        call.success();
+    }
+
+    @PluginMethod()
+    public void isAutoInitEnabled(final PluginCall call) {
+        final boolean enabled = FirebaseMessaging.getInstance().isAutoInitEnabled();
+        JSObject data = new JSObject();
+        data.put("enabled", enabled);
+        call.success(data);
+    }
 }

--- a/android/src/main/java/com/getcapacitor/community/fcm/FCMPlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/fcm/FCMPlugin.java
@@ -79,7 +79,7 @@ public class FCMPlugin extends Plugin {
     }
 
     @PluginMethod()
-    public void setAutoInitEnabled(final PluginCall call) {
+    public void setAutoInit(final PluginCall call) {
         final boolean enabled = call.getBoolean("enabled", false);
         FirebaseMessaging.getInstance().setAutoInitEnabled(enabled);
         call.success();

--- a/ios/Plugin/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin/Plugin.m
@@ -8,4 +8,6 @@ CAP_PLUGIN(FCM, "FCMPlugin",
            CAP_PLUGIN_METHOD(unsubscribeFrom, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getToken, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(deleteInstance, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(setAutoInitEnabled, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(isAutoInitEnabled, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin/Plugin.m
@@ -8,6 +8,6 @@ CAP_PLUGIN(FCM, "FCMPlugin",
            CAP_PLUGIN_METHOD(unsubscribeFrom, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getToken, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(deleteInstance, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHOD(setAutoInitEnabled, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(setAutoInit, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(isAutoInitEnabled, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin/Plugin.swift
@@ -80,4 +80,16 @@ public class FCM: CAPPlugin, MessagingDelegate {
             }
         }
     }
+
+    @objc func setAutoInitEnabled(_ call: CAPPluginCall) {
+        let enabled: Bool = call.getBool("enabled") ?? false
+        Messaging.messaging().isAutoInitEnabled = enabled;
+        call.success();
+    }
+    
+    @objc func isAutoInitEnabled(_ call: CAPPluginCall) {
+        call.success([
+            "enabled": Messaging.messaging().isAutoInitEnabled
+        ]);
+    }
 }

--- a/ios/Plugin/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin/Plugin.swift
@@ -81,7 +81,7 @@ public class FCM: CAPPlugin, MessagingDelegate {
         }
     }
 
-    @objc func setAutoInitEnabled(_ call: CAPPluginCall) {
+    @objc func setAutoInit(_ call: CAPPluginCall) {
         let enabled: Bool = call.getBool("enabled") ?? false
         Messaging.messaging().isAutoInitEnabled = enabled;
         call.success();

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -9,4 +9,6 @@ export interface FCMProtocol {
   unsubscribeFrom(options: { topic: string }): Promise<{ message: string }>;
   getToken(): Promise<{ token: string }>;
   deleteInstance(): Promise<boolean>;
+  setAutoInitEnabled(options: { enabled: boolean }): Promise<void>;
+  isAutoInitEnabled(): Promise<{ enabled: boolean }>;
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -9,6 +9,6 @@ export interface FCMProtocol {
   unsubscribeFrom(options: { topic: string }): Promise<{ message: string }>;
   getToken(): Promise<{ token: string }>;
   deleteInstance(): Promise<boolean>;
-  setAutoInitEnabled(options: { enabled: boolean }): Promise<void>;
+  setAutoInit(options: { enabled: boolean }): Promise<void>;
   isAutoInitEnabled(): Promise<{ enabled: boolean }>;
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -48,8 +48,8 @@ export class FCM implements FCMProtocol {
    * Enabled/disabled auto initialization.
    * @param options
    */
-  setAutoInitEnabled(options: { enabled: boolean }): Promise<void> {
-    return FCMPlugin.setAutoInitEnabled({ enabled: options.enabled });
+  setAutoInit(options: { enabled: boolean }): Promise<void> {
+    return FCMPlugin.setAutoInit({ enabled: options.enabled });
   }
 
   /**

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -43,4 +43,19 @@ export class FCM implements FCMProtocol {
   deleteInstance(): Promise<any> {
     return FCMPlugin.deleteInstance();
   }
+
+  /**
+   * Enabled/disabled auto initialization.
+   * @param options
+   */
+  setAutoInitEnabled(options: { enabled: boolean }): Promise<void> {
+    return FCMPlugin.setAutoInitEnabled({ enabled: options.enabled });
+  }
+
+  /**
+   * Retrieve the auto initialization status.
+   */
+  isAutoInitEnabled(): Promise<{ enabled: boolean }> {
+    return FCMPlugin.isAutoInitEnabled();
+  }
 }


### PR DESCRIPTION
Fixes #52.

This PR implements auto initialization control in accordance with the Firebase docs[1][2].

Should I publish a separate PR for updating the `README.md` of this plugin?

[1] https://firebase.google.com/docs/cloud-messaging/android/client#prevent-auto-init
[2] https://firebase.google.com/docs/cloud-messaging/ios/client#prevent_auto_initialization