### PR TITLE
fix: migrate getToken to use FirebaseMessaging, #99

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/fcm/FCMPlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/fcm/FCMPlugin.java
@@ -63,12 +63,13 @@ public class FCMPlugin extends Plugin {
 
     @PluginMethod()
     public void getToken(final PluginCall call) {
-        FirebaseInstallations.getInstance().getToken(false).addOnSuccessListener(getActivity(), instanceIdResult -> {
+        FirebaseMessaging.getInstance().getToken().addOnCompleteListener(getActivity(), tokenResult -> {
             JSObject data = new JSObject();
-            data.put("token", instanceIdResult.getToken());
+            data.put("token", tokenResult.getResult());
             call.resolve(data);
         });
-        FirebaseInstallations.getInstance().getId().addOnFailureListener(e -> call.reject("Failed to get instance FirebaseID", e));
+
+        FirebaseMessaging.getInstance().getToken().addOnFailureListener(e -> call.reject("Failed to get FCM registration token", e));
     }
 
     @PluginMethod()


### PR DESCRIPTION
* migration used https://firebase.google.com/docs/projects/manage-installations?hl=en#retrieving-an-fcm-registration-token

This PR updates `getToken` for Android to use FirebaseMessaging instead of FirebaseInstallations, suggested by @sburnicki https://github.com/capacitor-community/fcm/issues/99#issuecomment-1086724322.
I tested it and `getToken` now returns FCM Token in the same format as with the workaround proposed by @eljass https://github.com/capacitor-community/fcm/issues/99#issuecomment-942273362.

Please test this PR if it works for you too and let me know, if there is anything else todo to get this merged.