### PR TITLE
Bump iOS target version to 13.0 for capacitor 4 and add prepare script.

### DIFF
--- a/CapacitorCommunityFcm.podspec
+++ b/CapacitorCommunityFcm.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author = package['author']
   s.source = { git: package['repository']['url'], tag: s.version.to_s }
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
-  s.ios.deployment_target = '12.0'
+  s.ios.deployment_target = '13.0'
   s.dependency 'Capacitor'
   s.dependency 'Firebase/Messaging'
   s.swift_version = '5.1'

--- a/ios/Plugin/Podfile
+++ b/ios/Plugin/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
-platform :ios, '12.0'
+platform :ios, '13.0'
 
 def capacitor_pods
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks

--- a/package.json
+++ b/package.json
@@ -14,17 +14,18 @@
     "release:minor": "standard-version release --release-as minor",
     "release:major": "standard-version release --release-as major",
     "contributors:add": "all-contributors add",
-    "contributors:gen": "all-contributors generate"
+    "contributors:gen": "all-contributors generate",
+    "prepare": "npm run build"
   },
   "author": "Stewan Silva",
   "license": "MIT",
   "dependencies": {
-    "@capacitor/core": "^3.0.1"
+    "@capacitor/core": "^4.0.0-beta.2"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.1",
-    "@capacitor/cli": "^3.0.1",
-    "@capacitor/ios": "^3.0.1",
+    "@capacitor/android": "^4.0.0-beta.2",
+    "@capacitor/cli": "^4.0.0-beta.2",
+    "@capacitor/ios": "^4.0.0-beta.2",
     "all-contributors-cli": "^6.16.0",
     "typescript": "~4.0.0"
   },


### PR DESCRIPTION
-  Updated the deployment targets throughout the plugin to iOS 13.0 to fall in line with the default deployment targets for Capacitor 4.
- Added `prepare` script to package.json to allow installing the module from github