### PR TITLE
chore(android): Use androidx.appcompat

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,10 +52,9 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
+    implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
-    androidTestImplementation 'com.android.support:support-annotations:28.0.0'
     implementation "com.google.firebase:firebase-messaging:$firebaseMessagingVersion"
-    implementation 'com.android.support:appcompat-v7:28.0.0'
 }


### PR DESCRIPTION
com.android.support:appcompat-v7 is deprecated, replace with androidx.appcompat as AndroidX dependencies are enforced since Capacitor 2