### PR TITLE
docs(ios): Use homebrew to install cocoaPods

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ Download the `google-services.json` file and copy it to `android/app/` directory
 
 ## iOS setup
 
-- `sudo gem install cocoapods` _(once a time)_
+- [Install homebrew](https://capacitorjs.com/docs/getting-started/environment-setup#homebrew) _(once)_
+- `brew install cocoapods` _(once a time)_
 - `ionic start my-cap-app --capacitor`
 - `cd my-cap-app`
 - `mkdir www && touch www/index.html`


### PR DESCRIPTION
using `sudo gem install cocoapods` causes problems on M1/2 macs, we recommend using homebrew to install Cocoapods


