### PR TITLE
Avoid Crashes If Play Services Unavailable

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/fcm/FCMPlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/fcm/FCMPlugin.java
@@ -64,23 +64,33 @@ public class FCMPlugin extends Plugin {
     @PluginMethod()
     public void getToken(final PluginCall call) {
         FirebaseMessaging.getInstance().getToken().addOnCompleteListener(getActivity(), tokenResult -> {
+            if (!tokenResult.isSuccessful()) {
+                Exception exception = tokenResult.getException();
+                Log.w("FIREBASE_TOKEN_ERROR", "Fetching FCM registration token failed", exception);
+                call.errorCallback(exception.getLocalizedMessage());
+                return;
+            }
             JSObject data = new JSObject();
             data.put("token", tokenResult.getResult());
             call.resolve(data);
         });
 
-        FirebaseMessaging.getInstance().getToken().addOnFailureListener(e -> call.reject("Failed to get FCM registration token", e));
     }
     
     @PluginMethod()
     public void refreshToken(final PluginCall call) {
         FirebaseMessaging.getInstance().deleteToken();
         FirebaseInstallations.getInstance().getToken(false).addOnSuccessListener(getActivity(), instanceIdResult -> {
+            if (!instanceIdResult.isSuccessful()) {
+                Exception exception = instanceIdResult.getException();
+                Log.w("FIREBASE_TOKEN_ERROR", "Fetching FCM registration token failed", exception);
+                call.errorCallback(exception.getLocalizedMessage());
+                return;
+            }
             JSObject data = new JSObject();
             data.put("token", instanceIdResult.getToken());
             call.resolve(data);
         });
-        FirebaseInstallations.getInstance().getId().addOnFailureListener(e -> call.reject("Failed to get instance FirebaseID", e));
     }
 
     @PluginMethod()


### PR DESCRIPTION
### Description
- We have been suffering a lot of crashes on Huawei devices and some other devices like Redmi and Oppo in `FCMPlugin.java`, it happened on the line `data.put("token", tokenResult.getResult());`.
```
Exception com.google.android.gms.tasks.RuntimeExecutionException: java.io.IOException: java.util.concurrent.ExecutionException: java.io.IOException: SERVICE_NOT_AVAILABLE
  at com.google.android.gms.tasks.zzw.getResult (com.google.android.gms:play-services-tasks@@18.0.1:3)
  at com.getcapacitor.community.fcm.FCMPlugin.lambda$getToken$6 (FCMPlugin.java:68)
  at com.getcapacitor.community.fcm.FCMPlugin$$ExternalSyntheticLambda0.onComplete
  at com.google.android.gms.tasks.zzi.run (com.google.android.gms:play-services-tasks@@18.0.1:1)
  at android.os.Handler.handleCallback (Handler.java:938)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loop (Looper.java:264)
  at android.app.ActivityThread.main (ActivityThread.java:8245)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:632)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1049)
```
- The reason for this error is that on some devices `google-play-services` is not installed or not working for some reason, and the code tries to access `tokenResult.getResult()` and it results in an exception which is not handled and the app crashes.
- `addOnFailureListener` listener wasn't invoked and the exception doesn't get handled
- By reviewing the [**docs**](https://firebase.google.com/docs/cloud-messaging/android/client#retrieve-the-current-registration-token) found that the failure in this case is handled in a different way which is the one used in this PR
- After this fix the app doesn't crash and the exception is handled

### Suggestion
- It would be good also if we check for google-play-services availability as mentioned [**here**](https://firebase.google.com/docs/cloud-messaging/android/client#sample-play), that will help the user to avoid using the app without FCM and not getting any notifications