### PR TITLE
fix: Use Capacitor ^5.0.0 instead of next

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,10 +51,10 @@
     "contributors:gen": "all-contributors generate"
   },
   "devDependencies": {
-    "@capacitor/android": "next",
-    "@capacitor/core": "next",
+    "@capacitor/android": "^5.0.0",
+    "@capacitor/core": "^5.0.0",
     "@capacitor/docgen": "^0.0.18",
-    "@capacitor/ios": "next",
+    "@capacitor/ios": "^5.0.0",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "^1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",
@@ -69,7 +69,7 @@
     "typescript": "~4.1.5"
   },
   "peerDependencies": {
-    "@capacitor/core": "next"
+    "@capacitor/core": "^5.0.0"
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",


### PR DESCRIPTION
Sorry, I didn't update the dependency versions once Capacitor 5 final was released.

Specially the @capacitor/core peer dependency will cause issues as other dependencies will be using the latest version and will conflict 