### PR TITLE
#149 Always return renewed token in refreshToken() on android

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/fcm/FCMPlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/fcm/FCMPlugin.java
@@ -84,13 +84,13 @@ public class FCMPlugin extends Plugin {
     
     @PluginMethod()
     public void refreshToken(final PluginCall call) {
-        FirebaseMessaging.getInstance().deleteToken();
-        FirebaseMessaging.getInstance().getToken().addOnCompleteListener(getActivity(), tokenResult -> {
-            JSObject data = new JSObject();
-            data.put("token", tokenResult.getResult());
-            call.resolve(data);
-        });
-        FirebaseMessaging.getInstance().getToken().addOnFailureListener(e -> call.reject("Failed to get FCM registration token", e));
+        FirebaseMessaging.getInstance().deleteToken().addOnCompleteListener((result) -> {
+            FirebaseMessaging.getInstance().getToken().addOnCompleteListener(getActivity(), tokenResult -> {
+                JSObject data = new JSObject();
+                data.put("token", tokenResult.getResult());
+                call.resolve(data);
+            }).addOnFailureListener(e -> call.reject("Failed to get FCM registration token", e));
+        }).addOnFailureListener(e -> call.reject("Failed to delete FCM registration token", e));
     }
 
     @PluginMethod()

--- a/ios/Plugin/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin/Plugin.m
@@ -7,6 +7,7 @@ CAP_PLUGIN(FCMPlugin, "FCM",
            CAP_PLUGIN_METHOD(subscribeTo, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(unsubscribeFrom, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getToken, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(refreshToken, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(deleteInstance, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setAutoInit, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(isAutoInitEnabled, CAPPluginReturnPromise);


### PR DESCRIPTION
Changed to always return renewed token by waiting for deleteToken() to complete.

And fix missing macro for refreshToken on iOS.


resolve #149 