### PR TITLE
fix: Add refreshToken method to Plugin.m

### DIFF
--- a/ios/Plugin/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin/Plugin.m
@@ -10,4 +10,5 @@ CAP_PLUGIN(FCMPlugin, "FCM",
            CAP_PLUGIN_METHOD(deleteInstance, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setAutoInit, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(isAutoInitEnabled, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(refreshToken, CAPPluginReturnPromise);
 )


### PR DESCRIPTION
This pr will fix the `{CODE: UNIMPLEMENTED}` issue for the **refreshToken** method in iOS.