### PR TITLE
fix(ios): updated cocopod firebase messaging version to 10.22.1.

### DIFF
--- a/ios/Plugin/Podfile
+++ b/ios/Plugin/Podfile
@@ -10,11 +10,11 @@ end
 
 target 'Plugin' do
   # Pods for IonicRunner
-  pod 'Firebase/Messaging', '8.1.1'
+  pod 'Firebase/Messaging', '10.22.1'
   capacitor_pods
 end
 
 target 'PluginTests' do
-  pod 'Firebase/Messaging', '8.1.1'
+  pod 'Firebase/Messaging', '10.22.1'
   capacitor_pods
 end


### PR DESCRIPTION
This will fix the [Third-party SDK requirements](https://developer.apple.com/support/third-party-SDK-requirements/) issue in iOS build.

* Issue https://github.com/capacitor-community/fcm/issues/168
