### PR TITLE
chore: Use FirebaseMessaging dependency

### DIFF
--- a/CapacitorCommunityFcm.podspec
+++ b/CapacitorCommunityFcm.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '14.0'
   s.dependency 'Capacitor'
-  s.dependency 'Firebase/Messaging'
+  s.dependency 'FirebaseMessaging'
   s.swift_version = '5.1'
   s.static_framework = true
 end

--- a/ios/Plugin/Podfile
+++ b/ios/Plugin/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
-platform :ios, '13.0'
+platform :ios, '14.0'
 
 def capacitor_pods
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
@@ -10,11 +10,11 @@ end
 
 target 'Plugin' do
   # Pods for IonicRunner
-  pod 'Firebase/Messaging', '8.1.1'
+  pod 'FirebaseMessaging', '~> 11'
   capacitor_pods
 end
 
 target 'PluginTests' do
-  pod 'Firebase/Messaging', '8.1.1'
+  pod 'FirebaseMessaging', '~> 11'
   capacitor_pods
 end


### PR DESCRIPTION
While `Firebase/Messaging` still works and supposedly there are no plans to delete it, it's deprecated and `FirebaseMessaging` should be used instead

> For apps that use CocoaPods, the Firebase pod is deprecated in v9.0 and higher. Instead, you need to reference product pods directly in your Podfile (for example, FirebaseCore instead of Firebase/Core and FirebaseFirestore instead of Firebase/Firestore).

https://firebase.google.com/docs/ios/setup#available-pods

This PR updates the dependency to use `FirebaseMessaging` instead, also updates the `Podfile` to use iOS 14 and use a newer version for development. 

Closes https://github.com/capacitor-community/fcm/pull/169